### PR TITLE
fix duplicate path

### DIFF
--- a/cmake/nap_app.cmake
+++ b/cmake/nap_app.cmake
@@ -155,7 +155,8 @@ add_license(rapidjson ${NAP_ROOT}/thirdparty/rapidjson/license.txt)
 add_license(rttr ${NAP_ROOT}/thirdparty/rttr/source/LICENSE.txt)
 add_license(tclap ${NAP_ROOT}/thirdparty/tclap/COPYING)
 
-# Update executable rpath
+# Update executable rpath if it hasn't been set already
+# Using a bash script, it checks if the '@executablepath/%{LIB_RPATH}/' already exists in the list displayed by 'otool -l'. If not, it calls the CMAKE_INSTALL_NAME_TOOL to install the name.
 if(APPLE)
     add_custom_command(TARGET ${PROJECT_NAME}
             POST_BUILD COMMAND

--- a/cmake/nap_app.cmake
+++ b/cmake/nap_app.cmake
@@ -155,6 +155,13 @@ add_license(rapidjson ${NAP_ROOT}/thirdparty/rapidjson/license.txt)
 add_license(rttr ${NAP_ROOT}/thirdparty/rttr/source/LICENSE.txt)
 add_license(tclap ${NAP_ROOT}/thirdparty/tclap/COPYING)
 
+# Update executable rpath
+if(APPLE)
+    add_custom_command(TARGET ${PROJECT_NAME}
+            POST_BUILD COMMAND
+            if ! otool -l $<TARGET_FILE:${PROJECT_NAME}> | grep -q @executable_path/${LIB_RPATH}/.\; then ${CMAKE_INSTALL_NAME_TOOL} -add_rpath "@executable_path/${LIB_RPATH}/." $<TARGET_FILE:${PROJECT_NAME}>\; fi)
+endif()
+
 # Install to packaged app
 install(FILES $<TARGET_FILE:${PROJECT_NAME}> PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE TYPE BIN OPTIONAL)
 install(FILES ${app_install_data_dir}/app.json TYPE BIN OPTIONAL)

--- a/cmake/nap_app.cmake
+++ b/cmake/nap_app.cmake
@@ -155,13 +155,6 @@ add_license(rapidjson ${NAP_ROOT}/thirdparty/rapidjson/license.txt)
 add_license(rttr ${NAP_ROOT}/thirdparty/rttr/source/LICENSE.txt)
 add_license(tclap ${NAP_ROOT}/thirdparty/tclap/COPYING)
 
-# Update executable rpath
-if(APPLE)
-    add_custom_command(TARGET ${PROJECT_NAME}
-            POST_BUILD COMMAND
-            ${CMAKE_INSTALL_NAME_TOOL} -add_rpath "@executable_path/${LIB_RPATH}/." $<TARGET_FILE:${PROJECT_NAME}>)
-endif()
-
 # Install to packaged app
 install(FILES $<TARGET_FILE:${PROJECT_NAME}> PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE TYPE BIN OPTIONAL)
 install(FILES ${app_install_data_dir}/app.json TYPE BIN OPTIONAL)

--- a/tools/fbxconverter/CMakeLists.txt
+++ b/tools/fbxconverter/CMakeLists.txt
@@ -13,7 +13,8 @@ set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER Tools)
 target_compile_definitions(${PROJECT_NAME} PRIVATE MODULE_NAME=${PROJECT_NAME})
 target_link_libraries(${PROJECT_NAME} naprender)
 
-# Update executable rpath
+# Update executable rpath if it hasn't been set already
+# Using a bash script, it checks if the '@executablepath/%{LIB_RPATH}/' already exists in the list displayed by 'otool -l'. If not, it calls the CMAKE_INSTALL_NAME_TOOL to add the install name.
 if(APPLE)
     add_custom_command(TARGET ${PROJECT_NAME}
             POST_BUILD COMMAND

--- a/tools/fbxconverter/CMakeLists.txt
+++ b/tools/fbxconverter/CMakeLists.txt
@@ -13,13 +13,6 @@ set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER Tools)
 target_compile_definitions(${PROJECT_NAME} PRIVATE MODULE_NAME=${PROJECT_NAME})
 target_link_libraries(${PROJECT_NAME} naprender)
 
-# Update executable rpath
-if(APPLE)
-    add_custom_command(TARGET ${PROJECT_NAME}
-            POST_BUILD COMMAND
-            ${CMAKE_INSTALL_NAME_TOOL} -add_rpath "@executable_path/${LIB_RPATH}/." $<TARGET_FILE:${PROJECT_NAME}>)
-endif()
-
 
 # ======================= UNIT TESTS
 enable_testing()

--- a/tools/fbxconverter/CMakeLists.txt
+++ b/tools/fbxconverter/CMakeLists.txt
@@ -13,6 +13,12 @@ set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER Tools)
 target_compile_definitions(${PROJECT_NAME} PRIVATE MODULE_NAME=${PROJECT_NAME})
 target_link_libraries(${PROJECT_NAME} naprender)
 
+# Update executable rpath
+if(APPLE)
+    add_custom_command(TARGET ${PROJECT_NAME}
+            POST_BUILD COMMAND
+            if ! otool -l $<TARGET_FILE:${PROJECT_NAME}> | grep -q @executable_path/${LIB_RPATH}/.\; then ${CMAKE_INSTALL_NAME_TOOL} -add_rpath "@executable_path/${LIB_RPATH}/." $<TARGET_FILE:${PROJECT_NAME}>\; fi)
+endif()
 
 # ======================= UNIT TESTS
 enable_testing()


### PR DESCRIPTION
These changes make it possible to build on Intel without having to manually delete 'xcode/bin' before each build.