### PR TITLE
Nap 0.8 additions

### DIFF
--- a/package_app.sh
+++ b/package_app.sh
@@ -10,6 +10,7 @@ echo "-e Include the Napkin editor"
 echo "-s MacOS code signature"
 echo "-n MacOS notarization profile"
 echo "-t Perform testing"
+echo "-E Include MacOS Entitlements file"
 
 # Make sure cmake is installed
 if ! [ -x "$(command -v cmake)" ]; then
@@ -55,8 +56,10 @@ zip_output=false
 include_napkin=false
 perform_testing=false
 delete_output=false
+entitlements_file=""
+include_entitlements=false
 
-while getopts 'b:s:n:zetd' OPTION; do
+while getopts 'b:s:n:zetdE' OPTION; do
   case "$OPTION" in
     b)
       build_directory="$OPTARG"
@@ -89,6 +92,10 @@ while getopts 'b:s:n:zetd' OPTION; do
     d)
       delete_output=true
       echo "Output will be deleted"
+      ;;
+    E)
+      entitlements_file="$OPTARG"
+      include_entitlements=true
       ;;
     ?)
       exit 1
@@ -222,7 +229,15 @@ if [ "$(uname)" = "Darwin" ]; then
   # Codesign MacOS app bundle
   if [ $codesign = true ]; then
     echo Codesigning MacOS bundle...
-    codesign -s "$code_signature" -f "install/$app_directory" --options runtime
+
+    # Sign with entitlements file if it was given
+    if [ $include_entitlements = true ]; then
+      echo Signing with entitlements file: $5
+      codesign -s "$3" -f "install/$app_directory" --options runtime --entitlements "$entitlements_file"
+    else
+      codesign -s "$code_signature" -f "install/$app_directory" --options runtime
+    fi
+    
     if ! [ $? -eq 0 ]; then
       exit 2
     fi

--- a/system_modules/napimgui/src/imgui/imconfig.h
+++ b/system_modules/napimgui/src/imgui/imconfig.h
@@ -86,16 +86,3 @@
 
 //---- Use 32-bit vertex indices (instead of default: 16-bit) to allow meshes with more than 64K vertices
 #define ImDrawIdx unsigned int
-
-// ---- Forward declare thread local ImGUI context
-struct ImGuiContext;
-extern thread_local ImGuiContext* ImGuiTLS;
-#define GImGui ImGuiTLS
-
-//---- Tip: You can add extra functions within the ImGui:: namespace, here or in your own headers files.
-//---- e.g. create variants of the ImGui::Value() helper for your low-level math types, or your own widgets/helpers.
-namespace ImGui
-{
-
-}
-

--- a/system_modules/naprender/src/renderservice.cpp
+++ b/system_modules/naprender/src/renderservice.cpp
@@ -89,6 +89,7 @@ RTTI_BEGIN_CLASS(nap::RenderServiceConfiguration, "Render service configuration"
 	RTTI_PROPERTY("EnableRobustBufferAccess",	&nap::RenderServiceConfiguration::mEnableRobustBufferAccess,	nap::rtti::EPropertyMetaData::Default, "Enables buffer bounds-checking on the GPU, only necessary for debugging purposes")
 	RTTI_PROPERTY("ShowLayers",					&nap::RenderServiceConfiguration::mPrintAvailableLayers,		nap::rtti::EPropertyMetaData::Default, "Print all available Vulkan layers to console")
 	RTTI_PROPERTY("ShowExtensions",				&nap::RenderServiceConfiguration::mPrintAvailableExtensions,	nap::rtti::EPropertyMetaData::Default, "Print all available Vulkan extensions to console")
+	RTTI_PROPERTY("SetWindowIcon",				&nap::RenderServiceConfiguration::mSetWindowIcon,	nap::rtti::EPropertyMetaData::Default, "Show NAP logo as app window icon")
 RTTI_END_CLASS
 
 RTTI_BEGIN_CLASS_NO_DEFAULT_CONSTRUCTOR(nap::RenderService, "Main interface for GPU Render (2D/3D) and Compute operations")
@@ -1370,11 +1371,14 @@ namespace nap
 		if (!window.isEmbedded())
 		{
 			// Set default window icon
-			auto* window_icon = getOrCreateDefaultWindowIcon(getModule());
-			if (window_icon != nullptr && !SDL_SetWindowIcon(window.getNativeWindow(), window_icon))
+			if (mSetWindowIcon)
 			{
-				Logger::error("Unable to set '%s' icon: %s",
-					window.mID.c_str(), SDL::getSDLError().c_str());
+				auto* window_icon = getOrCreateDefaultWindowIcon(getModule());
+				if (window_icon != nullptr && !SDL_SetWindowIcon(window.getNativeWindow(), window_icon))
+				{
+					Logger::error("Unable to set '%s' icon: %s",
+						window.mID.c_str(), SDL::getSDLError().c_str());
+				}
 			}
 
 			// Enable text input
@@ -1766,11 +1770,13 @@ namespace nap
 	// Set the currently active renderer
 	bool RenderService::init(nap::utility::ErrorState& errorState)
 	{
+		// Get config
+		auto* config = getConfiguration<RenderServiceConfiguration>();
+
 		// Attempt to initialize SDL video subsystem if not yet available
 		// TODO: Try to find a more clean, optimized way of handling this.
 		if (!SDL::videoInitialized())
 		{
-			auto* config = getConfiguration<RenderServiceConfiguration>();
 			mSDLInitialized = SDL::initVideo(config->mVideoDriver, errorState);
 			if (!errorState.check(mSDLInitialized, "Failed to init video subsystem"))
 				return false;
@@ -1779,7 +1785,10 @@ namespace nap
 		// Store selected video back-end
 		mVideoDriver = fromString(SDL::getCurrentVideoDriver());
 		Logger::info("Video backend: %s", toString(mVideoDriver).c_str());
-
+		
+		// Store config property
+		mSetWindowIcon = config->mSetWindowIcon;
+		
 		// Initialize engine
 		return initEngine(errorState);
 	}

--- a/system_modules/naprender/src/renderservice.h
+++ b/system_modules/naprender/src/renderservice.h
@@ -95,6 +95,7 @@ namespace nap
 		bool							mEnableRobustBufferAccess = false;							///< Property: 'EnableRobustBufferAccess' Enables buffer bounds-checking on the GPU. Only enable this when absolutely necessary for debugging your application.
 		bool							mPrintAvailableLayers = false;								///< Property: 'ShowLayers' If all the available Vulkan layers are printed to console
 		bool							mPrintAvailableExtensions = false;							///< Property: 'ShowExtensions' If all the available Vulkan extensions are printed to console
+		bool							mSetWindowIcon = true;										///< Property: 'SetWindowIcon' Whether app window icons should automatically be overriden with the default NAP icon.
 
 		rtti::TypeInfo					getServiceType() const override								{ return RTTI_OF(RenderService); }
 
@@ -1346,5 +1347,8 @@ namespace nap
 
 		// Video backend driver
 		EVideoDriver mVideoDriver = EVideoDriver::Unknown;
+		
+		// Whether to set the window icon of added windows to the default NAP icon.
+		bool									mSetWindowIcon = true;
 	};
 } // nap


### PR DESCRIPTION
This is a PR into stijnvanbeek:nap-0.8 which cherry-picks changes from 4dsound:update-to-nap-0.8.

- Adds the option to code sign with a Entitlements.plist file.
- Adds a SetWindowIcon property to be able to disable overwriting the icon defined in Icon.plist with the default NAP icon.
- Removes an unused forward declare that does not compile for me (_Undefined symbol: thread-local wrapper routine for ImGuiTLS_).